### PR TITLE
Improve accuracy of branch name check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-hooks",
   "description": "A collection of useful git hooks for angularJS repositories",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Stronati Andrea",
     "email": "astronati@vendini.com"

--- a/pre-push.sh
+++ b/pre-push.sh
@@ -4,7 +4,7 @@
 #
 # For a complete documentation see https://git-scm.com/docs/githooks
 
-PROTECTED_BRANCHES="^(master|devel)"
+PROTECTED_BRANCHES="^(master|devel)$"
 z40=0000000000000000000000000000000000000000
 with_refs=0
 


### PR DESCRIPTION
Allow branches starting with `devel` and `master` (like `devel-update`) to be pushed. The previous check would block anything that starts with `devel` or `master`, but not this is relaxed to only check matching names.

Fixes #2
